### PR TITLE
Implement minimal PHP CRM

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
-# crminimal
-CRM Minimalista criado no Codex ChatGPT
+# CRM Minimalista
+
+Projeto de CRM minimalista com HTML, CSS, JS e PHP.
+
+## Como configurar
+
+1. Edite `php/db.php` com as credenciais do seu banco MySQL.
+2. Crie as tabelas `User`, `Contact`, `Task` e `Opportunity` utilizando o phpMyAdmin ou script SQL conforme o esquema.
+3. Após registrar e fazer login em `index.html`, você será redirecionado para `dashboard.html`.
+
+O projeto utiliza PHP com PDO e senha criptografada para segurança.

--- a/contatos.html
+++ b/contatos.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+<meta charset="UTF-8">
+<title>Contatos</title>
+<link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+<nav>
+<a href="dashboard.html">Dashboard</a>
+<a href="tarefas.html">Tarefas</a>
+<a href="kanban.html">Oportunidades</a>
+</nav>
+<div class="container">
+<h2>Novo Contato</h2>
+<form action="php/contatos.php" method="POST">
+<input type="hidden" name="action" value="create">
+<input type="text" name="name" placeholder="Nome" required>
+<input type="email" name="email" placeholder="Email">
+<input type="text" name="phone" placeholder="Telefone">
+<input type="text" name="company" placeholder="Empresa">
+<textarea name="notes" placeholder="Notas"></textarea>
+<button type="submit">Salvar</button>
+</form>
+<h2>Meus Contatos</h2>
+<div id="lista-contatos"></div>
+</div>
+<script>
+fetch('php/contatos.php')
+.then(r=>r.json())
+.then(data=>{
+ const list=document.getElementById('lista-contatos');
+ list.innerHTML=data.map(c=>`<p>${c.name} - ${c.email}</p>`).join('');
+});
+</script>
+</body>
+</html>

--- a/css/style.css
+++ b/css/style.css
@@ -1,0 +1,31 @@
+* { box-sizing: border-box; }
+body {
+  font-family: Arial, sans-serif;
+  background: url('https://source.unsplash.com/1600x900/?nature') no-repeat center center fixed;
+  background-size: cover;
+  margin: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
+}
+.container {
+  background: rgba(255, 255, 255, 0.2);
+  backdrop-filter: blur(10px);
+  border-radius: 10px;
+  padding: 20px;
+  width: 300px;
+  box-shadow: 0 4px 30px rgba(0,0,0,0.1);
+  color: #000;
+}
+input, button, textarea {
+  width: 100%;
+  padding: 8px;
+  margin: 5px 0;
+  border: none;
+  border-radius: 5px;
+}
+nav a { margin: 0 10px; color: #fff; text-decoration: none; }
+.kanban { display: flex; gap: 10px; }
+.column { flex: 1; background: rgba(255,255,255,0.2); padding: 10px; border-radius: 5px; min-height: 200px; }
+.card { background: rgba(255,255,255,0.6); margin:5px; padding:5px; border-radius:5px; cursor: grab; }

--- a/dashboard.html
+++ b/dashboard.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+<meta charset="UTF-8">
+<title>Dashboard</title>
+<link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+<nav>
+<a href="contatos.html">Contatos</a>
+<a href="tarefas.html">Tarefas</a>
+<a href="kanban.html">Oportunidades</a>
+<a href="index.html">Sair</a>
+</nav>
+<div class="container">
+<h1>Bem-vindo ao CRM</h1>
+<p>Escolha uma opção no menu.</p>
+</div>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+<meta charset="UTF-8">
+<title>Login</title>
+<link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+<div class="container">
+<h2>Login</h2>
+<form action="php/auth.php" method="POST">
+<input type="hidden" name="action" value="login">
+<input type="email" name="email" placeholder="Email" required>
+<input type="password" name="password" placeholder="Senha" required>
+<button type="submit">Entrar</button>
+</form>
+<hr>
+<h3>Registrar</h3>
+<form action="php/auth.php" method="POST">
+<input type="hidden" name="action" value="register">
+<input type="text" name="name" placeholder="Nome" required>
+<input type="email" name="email" placeholder="Email" required>
+<input type="password" name="password" placeholder="Senha" required>
+<button type="submit">Registrar</button>
+</form>
+</div>
+</body>
+</html>

--- a/js/kanban.js
+++ b/js/kanban.js
@@ -1,0 +1,28 @@
+const draggables = document.querySelectorAll('.card');
+const columns = document.querySelectorAll('.column');
+
+draggables.forEach(card => {
+  card.addEventListener('dragstart', () => card.classList.add('dragging'));
+  card.addEventListener('dragend', () => {
+    card.classList.remove('dragging');
+    save(card);
+  });
+});
+
+columns.forEach(column => {
+  column.addEventListener('dragover', e => {
+    e.preventDefault();
+    const dragging = document.querySelector('.dragging');
+    column.appendChild(dragging);
+  });
+});
+
+function save(card){
+  const id = card.dataset.id;
+  const stage = card.parentElement.dataset.stage;
+  fetch('php/oportunidades.php', {
+    method:'POST',
+    headers:{'Content-Type':'application/x-www-form-urlencoded'},
+    body:`id=${id}&stage=${stage}`
+  });
+}

--- a/js/kanban.js
+++ b/js/kanban.js
@@ -1,20 +1,23 @@
-const draggables = document.querySelectorAll('.card');
-const columns = document.querySelectorAll('.column');
-
-draggables.forEach(card => {
+function makeDraggable(card){
   card.addEventListener('dragstart', () => card.classList.add('dragging'));
   card.addEventListener('dragend', () => {
     card.classList.remove('dragging');
     save(card);
   });
-});
+}
 
-columns.forEach(column => {
-  column.addEventListener('dragover', e => {
-    e.preventDefault();
-    const dragging = document.querySelector('.dragging');
+function initDrag(){
+  document.querySelectorAll('.card').forEach(makeDraggable);
+}
+
+document.addEventListener('dragover', e => {
+  const column = e.target.closest('.column');
+  if(!column) return;
+  e.preventDefault();
+  const dragging = document.querySelector('.dragging');
+  if(dragging && column!==dragging.parentElement){
     column.appendChild(dragging);
-  });
+  }
 });
 
 function save(card){

--- a/kanban.html
+++ b/kanban.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+<meta charset="UTF-8">
+<title>Oportunidades</title>
+<link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+<nav>
+<a href="dashboard.html">Dashboard</a>
+<a href="contatos.html">Contatos</a>
+<a href="tarefas.html">Tarefas</a>
+</nav>
+<div class="kanban">
+<div class="column" data-stage="Novo">
+<h3>Novo</h3>
+</div>
+<div class="column" data-stage="Em Progresso">
+<h3>Em Progresso</h3>
+</div>
+<div class="column" data-stage="Ganho">
+<h3>Ganho</h3>
+</div>
+<div class="column" data-stage="Perdido">
+<h3>Perdido</h3>
+</div>
+</div>
+<script src="js/kanban.js"></script>
+<script>
+fetch('php/oportunidades.php')
+.then(r=>r.json())
+.then(data=>{
+ data.forEach(o=>{
+  const card=document.createElement('div');
+  card.className='card';
+  card.draggable=true;
+  card.dataset.id=o.id;
+  card.textContent=o.title;
+  document.querySelector(`[data-stage="${o.stage}"]`).appendChild(card);
+ });
+});
+</script>
+</body>
+</html>

--- a/kanban.html
+++ b/kanban.html
@@ -11,6 +11,16 @@
 <a href="contatos.html">Contatos</a>
 <a href="tarefas.html">Tarefas</a>
 </nav>
+<div class="container">
+<h2>Nova Oportunidade</h2>
+<form action="php/oportunidades.php" method="POST" id="form-opp">
+ <input type="hidden" name="action" value="create">
+ <input type="text" name="title" placeholder="Título" required>
+ <input type="number" step="0.01" name="value" placeholder="Valor">
+ <select name="contactId" id="contact-select"></select>
+ <button type="submit">Adicionar</button>
+</form>
+</div>
 <div class="kanban">
 <div class="column" data-stage="Novo">
 <h3>Novo</h3>
@@ -27,6 +37,12 @@
 </div>
 <script src="js/kanban.js"></script>
 <script>
+fetch('php/contatos.php')
+.then(r=>r.json())
+.then(data=>{
+ const sel=document.getElementById('contact-select');
+ sel.innerHTML=data.map(c=>`<option value="${c.id}">${c.name}</option>`).join('');
+});
 fetch('php/oportunidades.php')
 .then(r=>r.json())
 .then(data=>{
@@ -38,6 +54,7 @@ fetch('php/oportunidades.php')
   card.textContent=o.title;
   document.querySelector(`[data-stage="${o.stage}"]`).appendChild(card);
  });
+ initDrag();
 });
 </script>
 </body>

--- a/php/auth.php
+++ b/php/auth.php
@@ -1,0 +1,25 @@
+<?php
+require 'db.php';
+$action = $_POST['action'] ?? '';
+
+if ($action === 'register') {
+    $stmt = $pdo->prepare('INSERT INTO User (name,email,password) VALUES (?,?,?)');
+    $hash = password_hash($_POST['password'], PASSWORD_BCRYPT);
+    $stmt->execute([$_POST['name'], $_POST['email'], $hash]);
+    header('Location: ../index.html');
+    exit;
+}
+
+if ($action === 'login') {
+    $stmt = $pdo->prepare('SELECT * FROM User WHERE email = ?');
+    $stmt->execute([$_POST['email']]);
+    $user = $stmt->fetch();
+    if ($user && password_verify($_POST['password'], $user['password'])) {
+        $_SESSION['user_id'] = $user['id'];
+        header('Location: ../dashboard.html');
+    } else {
+        header('Location: ../index.html');
+    }
+    exit;
+}
+?>

--- a/php/contatos.php
+++ b/php/contatos.php
@@ -1,0 +1,23 @@
+<?php
+require 'db.php';
+$user = $_SESSION['user_id'] ?? 0;
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    if ($_POST['action'] === 'create') {
+        $stmt = $pdo->prepare('INSERT INTO Contact (name,email,phone,company,notes,userId) VALUES (?,?,?,?,?,?)');
+        $stmt->execute([
+            $_POST['name'],
+            $_POST['email'],
+            $_POST['phone'],
+            $_POST['company'],
+            $_POST['notes'],
+            $user
+        ]);
+    }
+    header('Location: ../contatos.html');
+    exit;
+}
+
+$stmt = $pdo->prepare('SELECT * FROM Contact WHERE userId=? ORDER BY id DESC');
+$stmt->execute([$user]);
+echo json_encode($stmt->fetchAll());

--- a/php/contatos.php
+++ b/php/contatos.php
@@ -2,6 +2,11 @@
 require 'db.php';
 $user = $_SESSION['user_id'] ?? 0;
 
+if (!$user) {
+    echo json_encode([]);
+    exit;
+}
+
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     if ($_POST['action'] === 'create') {
         $stmt = $pdo->prepare('INSERT INTO Contact (name,email,phone,company,notes,userId) VALUES (?,?,?,?,?,?)');

--- a/php/db.php
+++ b/php/db.php
@@ -1,0 +1,20 @@
+<?php
+$host = 'localhost';
+$db   = 'crm';
+$user = 'root';
+$pass = '';
+$charset = 'utf8mb4';
+
+$dsn = "mysql:host=$host;dbname=$db;charset=$charset";
+$options = [
+    PDO::ATTR_ERRMODE            => PDO::ERRMODE_EXCEPTION,
+    PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+    PDO::ATTR_EMULATE_PREPARES   => false,
+];
+try {
+    $pdo = new PDO($dsn, $user, $pass, $options);
+} catch (PDOException $e) {
+    throw new PDOException($e->getMessage(), (int)$e->getCode());
+}
+session_start();
+?>

--- a/php/oportunidades.php
+++ b/php/oportunidades.php
@@ -2,7 +2,24 @@
 require 'db.php';
 $user = $_SESSION['user_id'] ?? 0;
 
+if (!$user) {
+    echo json_encode([]);
+    exit;
+}
+
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    if (($_POST['action'] ?? '') === 'create') {
+        $stmt = $pdo->prepare('INSERT INTO Opportunity (title,stage,value,contactId,userId) VALUES (?,?,?,?,?)');
+        $stmt->execute([
+            $_POST['title'],
+            'Novo',
+            $_POST['value'] ?: null,
+            $_POST['contactId'],
+            $user
+        ]);
+        header('Location: ../kanban.html');
+        exit;
+    }
     $stmt = $pdo->prepare('UPDATE Opportunity SET stage=? WHERE id=? AND userId=?');
     $stmt->execute([$_POST['stage'], $_POST['id'], $user]);
     exit;

--- a/php/oportunidades.php
+++ b/php/oportunidades.php
@@ -1,0 +1,13 @@
+<?php
+require 'db.php';
+$user = $_SESSION['user_id'] ?? 0;
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $stmt = $pdo->prepare('UPDATE Opportunity SET stage=? WHERE id=? AND userId=?');
+    $stmt->execute([$_POST['stage'], $_POST['id'], $user]);
+    exit;
+}
+
+$stmt = $pdo->prepare('SELECT * FROM Opportunity WHERE userId=?');
+$stmt->execute([$user]);
+echo json_encode($stmt->fetchAll());

--- a/php/tarefas.php
+++ b/php/tarefas.php
@@ -1,0 +1,21 @@
+<?php
+require 'db.php';
+$user = $_SESSION['user_id'] ?? 0;
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    if ($_POST['action'] === 'create') {
+        $stmt = $pdo->prepare('INSERT INTO Task (title,description,dueDate,userId) VALUES (?,?,?,?)');
+        $stmt->execute([
+            $_POST['title'],
+            $_POST['description'],
+            $_POST['dueDate'],
+            $user
+        ]);
+    }
+    header('Location: ../tarefas.html');
+    exit;
+}
+
+$stmt = $pdo->prepare('SELECT * FROM Task WHERE userId=? ORDER BY id DESC');
+$stmt->execute([$user]);
+echo json_encode($stmt->fetchAll());

--- a/php/tarefas.php
+++ b/php/tarefas.php
@@ -2,6 +2,11 @@
 require 'db.php';
 $user = $_SESSION['user_id'] ?? 0;
 
+if (!$user) {
+    echo json_encode([]);
+    exit;
+}
+
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     if ($_POST['action'] === 'create') {
         $stmt = $pdo->prepare('INSERT INTO Task (title,description,dueDate,userId) VALUES (?,?,?,?)');

--- a/tarefas.html
+++ b/tarefas.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+<meta charset="UTF-8">
+<title>Tarefas</title>
+<link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+<nav>
+<a href="dashboard.html">Dashboard</a>
+<a href="contatos.html">Contatos</a>
+<a href="kanban.html">Oportunidades</a>
+</nav>
+<div class="container">
+<h2>Nova Tarefa</h2>
+<form action="php/tarefas.php" method="POST">
+<input type="hidden" name="action" value="create">
+<input type="text" name="title" placeholder="Título" required>
+<textarea name="description" placeholder="Descrição"></textarea>
+<input type="date" name="dueDate">
+<button type="submit">Salvar</button>
+</form>
+<h2>Minhas Tarefas</h2>
+<div id="lista-tarefas"></div>
+</div>
+<script>
+fetch('php/tarefas.php')
+.then(r=>r.json())
+.then(data=>{
+ const list=document.getElementById('lista-tarefas');
+ list.innerHTML=data.map(t=>`<p>${t.title} - ${t.completed ? 'Concluída':'Pendente'}</p>`).join('');
+});
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- build minimal pages (login, dashboard, contacts, tasks, kanban)
- add glassmorphism styles and vanilla JS for kanban drag & drop
- implement PHP backend with PDO for authentication and CRUD
- document setup steps

## Testing
- `php -l php/db.php`
- `php -l php/auth.php`
- `php -l php/contatos.php`
- `php -l php/tarefas.php`
- `php -l php/oportunidades.php`


------
https://chatgpt.com/codex/tasks/task_e_6849d356b358832a88e5a350534117ae